### PR TITLE
Use stream instade of SoftwareSerial or HardwareSerial

### DIFF
--- a/ESP8266.cpp
+++ b/ESP8266.cpp
@@ -21,19 +21,11 @@
 #include "ESP8266.h"
 #include <avr/pgmspace.h>
 
-#ifdef ESP8266_USE_SOFTWARE_SERIAL
-ESP8266::ESP8266(SoftwareSerial &uart): m_puart(&uart)
+ESP8266::ESP8266(Stream &uart): m_puart(&uart)
 {
     m_onData = NULL;
     m_onDataPtr = NULL;
 }
-#else
-ESP8266::ESP8266(HardwareSerial &uart): m_puart(&uart)
-{
-    m_onData = NULL;
-    m_onDataPtr = NULL;
-}
-#endif
 
 bool ESP8266::kick(void)
 {
@@ -632,7 +624,9 @@ bool ESP8266::eATSETUART(uint32_t baudrate,uint8_t pattern)
     m_puart->println(0);
     if(recvFind("OK",5000)){
 
-    m_puart->begin(baudrate);
+    // warn : you must call begin after changing baudrate
+    //m_puart->begin(baudrate);
+
     return true;
     }
     else{

--- a/ESP8266.h
+++ b/ESP8266.h
@@ -23,11 +23,8 @@
 
 #include "Arduino.h"
 
-//#define ESP8266_USE_SOFTWARE_SERIAL
+#include "Stream.h"
 
-#ifdef ESP8266_USE_SOFTWARE_SERIAL
-#include "SoftwareSerial.h"
-#endif
 
 #define  VERSION_18   		0X18
 #define  VERSION_22   		0X22
@@ -47,7 +44,6 @@ class ESP8266 {
 
     typedef void (*onData)(uint8_t mux_id, uint32_t len, void* ptr);
 
-#ifdef ESP8266_USE_SOFTWARE_SERIAL
     /*
      * Constuctor. 
      *
@@ -55,23 +51,10 @@ class ESP8266 {
      * @warning parameter baud depends on the AT firmware. 9600 is an common value. 
      */
 
-    ESP8266(SoftwareSerial &uart);
+    ESP8266(Stream &uart);
     
-    SoftwareSerial* getUart() { return m_puart; }
+    Stream* getUart() { return m_puart; }
 
-#else /* HardwareSerial */
-    /*
-     * Constuctor. 
-     *
-     * @param uart - an reference of HardwareSerial object. 
-     * @warning parameter baud depends on the AT firmware. 9600 is an common value. 
-     */
-
-    ESP8266(HardwareSerial &uart);
-    
-    HardwareSerial* getUart() { return m_puart; }
-
-#endif /* #ifdef ESP8266_USE_SOFTWARE_SERIAL */
 
     void setOnData(onData cbk, void* ptr) {
         m_onData = cbk;
@@ -142,7 +125,7 @@ class ESP8266 {
      * @param baudrate - the uart baudrate. 
      * @retval true - success. 
      * @retval false - failure. 
-     * @note  Only allows baud rate design, for the other parameters:databits- 8,stopbits -1,parity -0,flow control -0 . 
+     * @note  warn : you must call begin after changing baudrate. Only allows baud rate design, for the other parameters:databits- 8,stopbits -1,parity -0,flow control -0 .
      */
     bool setUart(uint32_t baudrate,uint8_t pattern);
     
@@ -690,11 +673,8 @@ class ESP8266 {
      * +IPD,id,len:data
      */
     
-#ifdef ESP8266_USE_SOFTWARE_SERIAL
-    SoftwareSerial *m_puart; /* The UART to communicate with ESP8266 */
-#else
-    HardwareSerial *m_puart; /* The UART to communicate with ESP8266 */
-#endif
+    Stream *m_puart; /* The UART to communicate with ESP8266 */
+
     onData m_onData;
     void*  m_onDataPtr;
 };


### PR DESCRIPTION
I think it's realy bad to get 2 libraries 1 for SoftwareSerial and other for HardwareSerial (I see it in Blynk project).

Why don't use Stream ?